### PR TITLE
PHP 8

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -8,7 +8,6 @@ requires:
         media_manager: '^2.0.0'
         yrewrite: '^2.0.0'
     redaxo: '^5.2.0'
-    php: '^7'
 
 pages:
     yrewrite/mm_autorewrite:

--- a/package.yml
+++ b/package.yml
@@ -8,6 +8,7 @@ requires:
         media_manager: '^2.0.0'
         yrewrite: '^2.0.0'
     redaxo: '^5.2.0'
+    php: '>=7.2.0'
 
 pages:
     yrewrite/mm_autorewrite:


### PR DESCRIPTION
Addon lässt sich unter PHP nicht installieren, obwohl es gut funktioniert. Versionsvoraussetzung entfernt.