### PR TITLE
Bugfix für Pfade mit Parametern

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -45,6 +45,8 @@ if (!rex::isBackend()) {
             $ep->getSubject())
         );
 
+        $ep->setSubject( preg_replace('/(media\/[^&]+)&/', '$1?', $ep->getSubject()));
+        
         return $ep->getSubject();
     });
 }


### PR DESCRIPTION
Sollte es Pfade geben, z.B.: 
index.php?rex_media_type=ImgTypeName&rex_media_file=ImageFileName&id=1

wird dies aktuell zu 
media/mediatype/filename.jpg&id=1 
und nun zu 
media/mediatype/filename.jpg?id=1

Behebt Issue #26